### PR TITLE
Fix Ubuntu CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,10 +21,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Install system dependencies [Linux]
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt update
+        sudo apt install \
+          libasound2-dev \
+          libpulse-dev \
+          libjack-jackd2-dev
+
     - name: Install Node.js
       uses: actions/setup-node@v2
       with:
         node-version: ${{ env.NODE_VERSION }}
+
     - name: Install dependencies
       run: npm install
 


### PR DESCRIPTION
audify npm package -> compiles RtAudio library -> requires some system packages for various supported audio APIs.

> ```
> npm ERR! -- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1") 
> npm ERR! -- Checking for module 'jack'
> npm ERR! --   No package 'jack' found
> npm ERR! -- Checking for module 'libpulse-simple'
> npm ERR! --   No package 'libpulse-simple' found
> npm ERR! -- Looking for gettimeofday
> npm ERR! -- Looking for gettimeofday - found
> npm ERR! -- Could NOT find ALSA (missing: ALSA_LIBRARY ALSA_INCLUDE_DIR) 
> npm ERR! -- Configuring incomplete, errors occurred!
> ```